### PR TITLE
more compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ keymap is `gO` on any urls.py line:
   * `r'index', direct_to_template, {'template_name': 'app/index.html'}, ...`  
       will take you to templates/app/index.html
 
-only work good with str style of view at one line
+only work good with str style of view at one line  
 so, django and web.py's url can be parsed.
 
-No settings are imported and no django modules used.
+No settings are imported and no django modules used.  
 see the source, for more detail.
 
 Have fun!

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ only work good with str style of view at one line
 so, django and web.py's url can be parsed.
 
 No settings are imported and no django modules used.  
-see the source, for more detail.
+see the source, for more detail.  
 
-Have fun!
+combine with youcompleteme, would be more convenient!
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Install:
 
-* Put vimango.vim in $VIMRUNTIME/plugin
+* Put vimango.vim in $VIMRUNTIME/plugin  
     using vundle would be better
 
-* Put vimango.py in $PYTHONPATH
+* Put vimango.py in $PYTHONPATH  
     e.g. sudo ln -sf ~/.vim/bundle/ViMango/plugin/vimango.py /usr/local/lib/python2.7/dist-packages/vimango.py
 
 keymap is `gO` on any urls.py line:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 Install:
 
 * Put vimango.vim in $VIMRUNTIME/plugin
-* Put vimango.py in $PYTHONPATH
+    using vundle would be better
 
-Pressing `<F2>` on any urls.py line:
+* Put vimango.py in $PYTHONPATH
+    e.g. sudo ln -sf ~/.vim/bundle/ViMango/plugin/vimango.py /usr/local/lib/python2.7/dist-packages/vimango.py
+
+keymap is `gO` on any urls.py line:
 
   * `r'^url/$', 'app.views.func', ...`  
       will take you to `func` in app/views.py
@@ -14,7 +17,11 @@ Pressing `<F2>` on any urls.py line:
   * `r'index', direct_to_template, {'template_name': 'app/index.html'}, ...`  
       will take you to templates/app/index.html
 
+only work good with str style of view at one line
+so, django and web.py's url can be parsed.
+
 No settings are imported and no django modules used.
+see the source, for more detail.
 
 Have fun!
 

--- a/plugin/vimango.py
+++ b/plugin/vimango.py
@@ -1,4 +1,5 @@
 def get_view_from_url(line, settings):
+    jzz = ' | normal jzz'
     def file_grep_wrapper(file_grep):
         import os
         is_file = os.path.exists(file_grep)
@@ -8,7 +9,7 @@ def get_view_from_url(line, settings):
         return file_grep
 
     def get_vim_cmd(func, file_grep):
-        return settings['grep'] + " /\(def\|class\) \+" + func + "/g " + file_grep_wrapper(file_grep)
+        return settings['grep'] + " /\(def\|class\) \+" + func + "/g " + file_grep_wrapper(file_grep) + jzz
 
     def find_quote(oneline):
         for an_alpha in oneline:
@@ -28,20 +29,23 @@ def get_view_from_url(line, settings):
         import re
         template = re.sub('''('|"|}\)?$)''', '', line.split(',')[2].split(':')[1].strip())
         file_grep = '%s%s%s' % (settings['apps'], settings['templates'], template)
-        vim_cmd = '%s %s' %(settings['open'], file_grep_wrapper(file_grep))
+        vim_cmd = '%s %s%s' %(settings['open'], file_grep_wrapper(file_grep), jzz)
         del re
     else:
         parse_list = parse_type.split(find_quote(parse_type))
-        parsed = parse_list[1]
+        try:
+            parsed = parse_list[1]
+        except:
+            return "echo 'can not find the view. Is it a str wrapped by quote?'"
         num_dots = parsed.count(".")
         if num_dots == 0:
             app = settings['buffer']
-            vim_cmd = settings['grep'] + " /\(def\|class\) \+" + parsed + "/g " + app + "/" + "views.py"
+            vim_cmd = settings['grep'] + " /\(def\|class\) \+" + parsed + "/g " + app + "/" + "views.py" + jzz
         elif num_dots == 1:
             app_or_views, urls_or_func = parsed.split('.')
             if 'include(' in parse_list[0]:
                 file_grep = settings['apps'] + app_or_views + "/" + urls_or_func + ".py"
-                vim_cmd = settings['open'] + " " + file_grep_wrapper(file_grep)
+                vim_cmd = settings['open'] + " " + file_grep_wrapper(file_grep) + jzz
             else:
                 file_grep = settings['apps'] + app_or_views + ".py"
                 vim_cmd = get_vim_cmd(urls_or_func, file_grep)

--- a/plugin/vimango.py
+++ b/plugin/vimango.py
@@ -1,19 +1,54 @@
 def get_view_from_url(line, settings):
+    def file_grep_wrapper(file_grep):
+        import os
+        is_file = os.path.exists(file_grep)
+        del os
+        if not is_file:
+            return '../' + file_grep
+        return file_grep
+
+    def get_vim_cmd(func, file_grep):
+        return settings['grep'] + " /\(def\|class\) \+" + func + "/g " + file_grep_wrapper(file_grep)
+
+    def find_quote(oneline):
+        for an_alpha in oneline:
+            if an_alpha is "'":
+                return "'"
+                break
+            elif an_alpha is "\"":
+                return "\""
+                break
+
+    vim_cmd = 'echo "sorry, i tried..."'
+    quote_id = find_quote(line)
+    #prune re str for some special char
+    line = line[line.index(quote_id, line.index(quote_id)+1):]
     parse_type = line.split(',')[1]
     if parse_type.strip() == 'direct_to_template':
-        template = line.split(',')[2].split(":")[1].strip().replace("\"", "").rstrip("}")
-        vim_cmd = "%s %s%s" %(settings['open'], settings['templates'], template)
+        import re
+        template = re.sub('''('|"|}\)?$)''', '', line.split(',')[2].split(':')[1].strip())
+        file_grep = '%s%s%s' % (settings['apps'], settings['templates'], template)
+        vim_cmd = '%s %s' %(settings['open'], file_grep_wrapper(file_grep))
+        del re
     else:
-        parsed = parse_type.split("'")[1]
+        parse_list = parse_type.split(find_quote(parse_type))
+        parsed = parse_list[1]
         num_dots = parsed.count(".")
         if num_dots == 0:
             app = settings['buffer']
-            vim_cmd = settings['grep'] + " /def " + parsed + "/g " + app + "/" + "views.py"
+            vim_cmd = settings['grep'] + " /\(def\|class\) \+" + parsed + "/g " + app + "/" + "views.py"
         elif num_dots == 1:
-            app, urls = parsed.split('.')
-            vim_cmd = settings['open'] + " " + settings['apps'] + app + "/" + urls + ".py"
-        elif num_dots == 2:
-            app, views, func = parsed.split('.')
-            vim_cmd = settings['grep'] + " /def " + func + "/g " + settings['apps'] + app + "/" + views + ".py"
+            app_or_views, urls_or_func = parsed.split('.')
+            if 'include(' in parse_list[0]:
+                file_grep = settings['apps'] + app_or_views + "/" + urls_or_func + ".py"
+                vim_cmd = settings['open'] + " " + file_grep_wrapper(file_grep)
+            else:
+                file_grep = settings['apps'] + app_or_views + ".py"
+                vim_cmd = get_vim_cmd(urls_or_func, file_grep)
+        elif num_dots >= 2:
+            parsed_list = parsed.split('.')
+            the_view = parsed_list[0:-1]
+            file_grep = settings['apps'] + '/'.join(the_view) + ".py"
+            vim_cmd = get_vim_cmd(parsed_list[-1], file_grep)
     return vim_cmd
 

--- a/plugin/vimango.vim
+++ b/plugin/vimango.vim
@@ -48,7 +48,7 @@ def main():
 
 EOF
 
-noremap gO :python main()<CR>j
+noremap gO :python main()<CR>jzz
 
 let &cpo = s:save_cpo
 

--- a/plugin/vimango.vim
+++ b/plugin/vimango.vim
@@ -48,7 +48,7 @@ def main():
 
 EOF
 
-map <F2> :python main()<CR>j
+noremap gO :python main()<CR>j
 
 let &cpo = s:save_cpo
 

--- a/plugin/vimango.vim
+++ b/plugin/vimango.vim
@@ -48,7 +48,7 @@ def main():
 
 EOF
 
-noremap gO :python main()<CR>jzz
+nnoremap gO :python main()<CR>jzz
 
 let &cpo = s:save_cpo
 

--- a/plugin/vimango.vim
+++ b/plugin/vimango.vim
@@ -48,7 +48,7 @@ def main():
 
 EOF
 
-nnoremap gO :python main()<CR>jzz
+nnoremap gO :python main()<CR>
 
 let &cpo = s:save_cpo
 


### PR DESCRIPTION
1. can open vim in urls.py or manage.py's directory
   which infects vim's pwd and then vimgrep wrong path
2. add jumping to view as class in web.py
3. prune re from line in case that regex contains "," 
4. modify readme's mesg
